### PR TITLE
fix: storybook absolute imports and module path aliases

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
This pull request addresses the issue with **absolute imports and module path aliases** in Storybook by introducing a baseUrl configuration. When baseUrl is configured as ".", TypeScript will resolve these imports based on the root directory of the project. This enhancement ensures more efficient and organized module resolution within the Storybook environment.
We can now use imports like `import {cn} from "@/lib/utils" `

![image](https://github.com/forjadev/mjo-forja-webpage/assets/61201131/5c99770a-abbb-4653-934d-01410e6c39d7)

Documentation: https://github.com/storybookjs/storybook/blob/next/code/frameworks/nextjs/README.md#supported-features
